### PR TITLE
add I% symbol for 12-hour clock

### DIFF
--- a/lib/stringIO.zig
+++ b/lib/stringIO.zig
@@ -21,7 +21,7 @@ const FormatCode = enum(u8) {
     // %y ?
     year = 'Y',
     hour = 'H',
-    // %I ?
+    hour12 = 'I', // 12-hour clock
     // %p ? // locale-specific
     min = 'M',
     sec = 'S',
@@ -51,6 +51,7 @@ const FormatCode = enum(u8) {
             .year => try writer.print("{d:0>4}", .{dt.year}),
             .day => try writer.print("{d:0>2}", .{dt.day}),
             .hour => try writer.print("{d:0>2}", .{dt.hour}),
+            .hour12 => try writer.print("{d:0>2}", .{twelve_hour_format(dt.hour)}),
             .min => try writer.print("{d:0>2}", .{dt.minute}),
             .sec => try writer.print("{d:0>2}", .{dt.second}),
             .nanos => try writer.print("{d:0>9}", .{dt.nanosecond}),
@@ -326,6 +327,11 @@ fn parseOffset(comptime T: type, dt_string: []const u8, idx: *usize, maxDigits: 
     const minutes = @divFloor(remainder, 100);
     const seconds = @mod(remainder, 100);
     return sign * (hours * 3600 + minutes * 60 + seconds);
+}
+
+// Turn 24 hour clock into 12 hour clock
+fn twelve_hour_format(hour: u8) u8 {
+    return if (hour == 0 or hour == 12) 12 else hour % 12;
 }
 
 // -----

--- a/tests/test_stringIO.zig
+++ b/tests/test_stringIO.zig
@@ -232,6 +232,39 @@ test "format with month name" {
     try testing.expectEqualStrings(string, s.items);
 }
 
+test "format with 12 hour clock" {
+    if (!locale_ok()) return error.SkipZigTest;
+
+    const HourTestCase = struct {
+        hour: u8,
+        expected: []const u8,
+    };
+
+    const test_cases = [_]HourTestCase{
+        .{ .hour = 0, .expected = "12:00:00" },
+        .{ .hour = 1, .expected = "01:00:00" },
+        .{ .hour = 11, .expected = "11:00:00" },
+        .{ .hour = 12, .expected = "12:00:00" },
+        .{ .hour = 13, .expected = "01:00:00" },
+        .{ .hour = 23, .expected = "11:00:00" },
+    };
+
+    for (test_cases) |case| {
+        const dt = try Datetime.fromFields(.{
+            .year = 2024,
+            .month = 1,
+            .day = 1,
+            .hour = case.hour,
+        });
+
+        var buf = std.ArrayList(u8).init(testing.allocator);
+        defer buf.deinit();
+
+        try zdt.formatToString(buf.writer(), "%I:%M:%S", dt);
+        try testing.expectEqualStrings(case.expected, buf.items);
+    }
+}
+
 // ---- String to Datetime ----
 
 test "comptime parse with comptime format string" {


### PR DESCRIPTION
A small pr to get the `%I` symbol working.

This package is great! I'd be happy to help get more of the symbols implemented.

Let me know if any adjustments are needed.