### PR TITLE
Timezone pointers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,35 +1,59 @@
 # CHANGELOG
 
+<https://keepachangelog.com/>
+
+Types of changes
+
+- 'Added' for new features.
+- 'Changed' for changes in existing functionality.
+- 'Deprecated' for soon-to-be removed features.
+- 'Removed' for now removed features.
+- 'Fixed' for any bug fixes.
+- 'Security' in case of vulnerabilities.
+
+## Unreleased
+
+### Changed
+
+- internal: string methods error handling
+
 ## 2024-09-20, v0.3.0
 
-- breaking changes!: major API revision, mainly string input/output
+### Added
+
+- method `nowUTC` to Datetime that returns UTC (aware datetime) without needing a timezone argument and returns no error
+
+### Changed
+
+- major API revision, mainly string input/output
   - Datetime now has `toString` and `fromString`, as well as `fromISO8601` as a shortcut for ISO8601-compatible input
   - string.zig and calendar.zig aren't exported anymore (stringIO.zig is now string.zig), to keep the API concise
-- `toString`: correctly handle naive datetime with 'i', 'z' and 'Z' directives
-- remove method `nowLocal` from Datetime; this can be achieved with `now` plus `Timezone.tzLocal`
-- added method `nowUTC` to Datetime that returns UTC (aware datetime) without needing a timezone argument and returns no error
-- change `now` to return an error union, in case loading the timezone causes an error
-- remove POSIX TZ provisions since this is currently not planned
+- `now` returns an error union, in case loading the timezone causes an error
 
+### Fixed
+
+- `toString`: correctly handle naive datetime with 'i', 'z' and 'Z' directives
+
+### Removed
+
+- POSIX TZ provisions since this is currently not planned
+- method `nowLocal` from Datetime; this can be achieved with `now` plus `Timezone.tzLocal`
 
 ## 2024-09-15, v0.2.3
 
-- datetime to string: %I directive, by @sethvincent 
+- datetime to string: %I directive, by @sethvincent
 - datetime to string, string to datetime: 'am' and 'pm' added, to complement %I
 - formatting directives (dt-->str) mostly completed, missing: locale-specific `%c`, `%x` and `%X` (addresses part of issue #5)
 - generator script, tz database: checkout specific tag before building the database (addresses part of issue #4)
-
 
 ## 2024-09-08, v0.2.2
 
 - update IANA tzdata to 2024b
 
-
 ## 2024-08-28, v0.2.1
 
 - change of ergonomics: `formatToString`, `parseToDatetime` and `parseISO8601` functions are now methods of the `zdt` struct (formerly `stringIO.[...]`). After importing zdt, they can be called like `zdt.formatToString` etc.
 - this is the first version that will be on github only. Having the same repository at both Codeberg and github is just too cumbersome.
-
 
 ## 2024-08-07, v0.2.0
 
@@ -37,20 +61,17 @@
   - since StaticStringMap is not available with Zig 0.12, Zig 0.13+ is required
 - fix code generator steps in build.zig to only run on the host as target
 
-
 ## 2024-08-06, v0.1.6
 
 - renamings; replace 'self' with more meaningful designation
 - remove 'clean' step from build.zig
 - last version that supports both Zig 0.12 and 0.13
 
-
 ## 2024-07-07, v0.1.5
 
 - add option to truncate fractional second via 's.:[precision]' formatting directive
 - limit what is exposed from ./util via the zon file
 - satisfy zig-0.14 deprecations
-
 
 ## 2024-06-18, v0.1.4
 
@@ -59,22 +80,18 @@
 - add %j directive, implement datetime --> string
 - add %T directive, implement datetime <--> string
 
-
 ## 2024-06-15, v0.1.3
 
 - introduce helper functions isAware and isNaive for Datetime struct
 - make tz name validator public (Timezone.identifierValid)
 
-
 ## 2024-06-09
 
 - cleaun-up calendar.zig
 
-
 ## 2024-05-30
 
 - add autodoc workflow, gh pages
-
 
 ## 2024-05-28, v0.1.2
 
@@ -82,22 +99,18 @@
 - some windows-tzdb generator tweaks
 - tzdb update
 
-
 ## 2024-05-19, v0.1.1
 
 - use base2 sized integers for better performance
 - TZ format: use 'c'-directive to signal that those are ASCII-encoded strings
 
-
 ## 2024-05-04, v0.1.0
 
 - cleanup
 
-
 ## 2024-04-04
 
 - runtime loading of tzfile: accept period as part of identifier (path)
-
 
 ## 2024-03-16
 
@@ -109,7 +122,6 @@
 - add 'clean' step to build.zig, to remove ./zig-out and ./zig-cache
 - more stuff added to docs
 
-
 ## 2024-03-09
 
 - add string input/output example
@@ -117,13 +129,11 @@
 - build.zig.zon: explicitly specify included files and directories
 - windows-tz: read Windows tz name from registry instead of using `tzutil`
 
-
 ## 2024-02-28
 
 - documentation updates
 - add locale specific formatting directives %a, %A, %b and %B (datetime to string)
 - tzLocalize: accept aware datetime (creates new datetime with same fields but different time zone)
-
 
 ## 2024-02-23
 
@@ -132,7 +142,6 @@
 - refine duration methods, 'fromTimespanMultiple' and 'toTimespanMultiple'
 - add duration example
 
-
 ## 2024-02-16
 
 - bugfix `epoch` constant
@@ -140,12 +149,10 @@
 - remove `naiveFromList` method - datetime instance should be created via `fromFields`
 - update readme, add demo (example)
 
-
 ## 2024-02-13
 
 - revise name and abbreviation of time zones
 - update tzdb version to 2024a
-
 
 ## 2024-02-09
 
@@ -153,13 +160,11 @@
 - internal revision which methods should operate on pointers and which on values
 - tz abbreviation awailable via formatDatetime method (stringIO module)
 
-
 ## 2024-01-31
 
 - automatically set time zone database prefix when the library is used by another package
 - tz db prefix can also set to a user-specified path via build options
 - add local tz method (implemented for linux, windows)
-
 
 ## 2024-01-24
 
@@ -168,12 +173,10 @@
 - tzfiles from the database that is shipped with zdt (eggert/tz) are comptime-loaded by default
 - runtime-loading of TZif files now has to be done via a separate function
 
-
 ## 2024-01-19
 
 - some restructuring where stuff is located in the module's directory, no effect on code itself
 - prepare embedding zoneinfo data; latest version is obtained by Python script
-
 
 ## 2024-01-10
 
@@ -185,14 +188,12 @@
 - add docs generate step to build script
 - add semantic version to build script
 
-
 ## 2024-01-07
 
 - restructured datetime and timezone, both files now offer the type (struct) directly
 - add tzif parser from the standard lib as a source file
 - add epoch constant
 - zig_0.12-dev branch: runs with latest dev version - fixes tz abbreviation bug, but excludes zBench since this requires 0.11.0
-
 
 ## 2024-01-03
 
@@ -201,13 +202,11 @@
 - use Neri-Schneider algorithms for date <--> Unix time
 - add method to determine leap seconds offset for given Unix time
 
-
 ## 2024-01-02
 
 - add day-of-year method
 - add day-of-week and iso-day-of-week methods
 - tzfile bugfix: correct offset determination for zones that only have one timetype
-
 
 ## 2024-01-02
 
@@ -216,13 +215,11 @@
 - parse 'Z' to a named offset, UTC
 - add parser benchmark
 
-
 ## 2023-12-30
 
 - parser / DatetimeFields: accept leap second input
 - parser: fix bug with incomplete fractional input (< 9 digits)
 - add ISO8601 parser
-
 
 ## 2023-12-27
 
@@ -230,19 +227,16 @@
 - adhere to ziglang naming convention
 - revise TZ deinit method, make sure to free tzfile memory
 
-
 ## 2023-12-22
 
 - revise TZ struct and attachment logic of datetime-->timezone
 - add comparison methods for UT and wall time
 - add datetime demo
 
-
 ## 2023-12-21
 
 - add 'now' method
 - allow seconds in UTC offset
-
 
 ## 2023-12-21
 
@@ -250,47 +244,38 @@
 - add time zone conversion method
 - offset tz: check range
 
-
 ## 2023-12-20
 
 - datetime from fields with time zone handles ambiguous and non-existent datetime
-
 
 ## 2023-12-18
 
 - add benchmark for calendric functions (r.d. <--> date)
 
-
 ## 2023-12-16
 
 - some basic time zone calculations working
-
 
 ## 2023-12-10
 
 - set 0.1.0 tag
 
-
 ## 2023-12-06
 
 - prepare for restart
-
 
 ## 2023-11-26
 
 - structural changes, where to put tests etc.
 - include zBench via build.zig.zon
 
-
 ## 2023-11-23
 
 - benchmarks as binary; install-artifact, not test in build script
 
-
 ## 2023-11-02
 
 - integrate zBench from fork
-
 
 ## 2023-10-23
 

--- a/lib/Timezone.zig
+++ b/lib/Timezone.zig
@@ -1,4 +1,4 @@
-//! a set of rules to describe date and time somewhere on earth, relative to universal time (UTC)
+//! A set of rules to describe date and time somewhere on earth, relative to universal time (UTC).
 
 const std = @import("std");
 const builtin = @import("builtin");
@@ -40,8 +40,8 @@ const comptime_tzdb_prefix = "./tzdata/zoneinfo/"; // IANA db as provided by the
 /// RFC8536, sect. 3.2, TZif data block.
 pub const UTC_off_range = [2]i32{ -89999, 93599 };
 
-/// offset from UTC, in seconds East of Greenwich.
-/// this type can be used for any datetime, given a time zone rule.
+/// Offset from UTC, in seconds East of Greenwich.
+/// This type can be used for any datetime, given a time zone rule.
 pub const UTCoffset = struct {
     seconds_east: i32 = 0,
     is_dst: bool = false,
@@ -59,7 +59,7 @@ pub const UTC = Timezone{
     .__name_data = [3]u8{ 85, 84, 67 } ++ std.mem.zeroes([cap_name_data - 3]u8),
 };
 
-/// A time zone's name (identifier)
+/// A time zone's name (identifier).
 pub fn name(tz: *Timezone) []const u8 {
     // 'tz' must be a pointer to TZ, otherwise returned slice would point to an out-of-scope
     // copy of the TZ instance. See also <https://ziggit.dev/t/pointers-to-temporary-memory/>
@@ -179,7 +179,7 @@ pub fn fromOffset(offset_sec_East: i32, identifier: []const u8) TzError!Timezone
     };
 }
 
-/// Clear a TZ instance and free potentially used memory (tzFile)
+/// Clear a TZ instance and free potentially used memory (tzFile).
 pub fn deinit(tz: *Timezone) void {
     if (tz.tzFile != null) {
         tz.tzFile.?.deinit(); // free memory allocated for the data from the tzfile
@@ -191,9 +191,9 @@ pub fn deinit(tz: *Timezone) void {
     tz.__name_data_len = 0;
 }
 
-/// Try to obtain the system's local time zone
+/// Try to obtain the system's local time zone.
 ///
-/// Note, Windows OS: Windows does not use the IANA time zone database;
+/// Note: Windows does not use the IANA time zone database;
 /// a mapping from Windows db to IANA db is prone to errors.
 /// Use with caution.
 pub fn tzLocal(allocator: std.mem.Allocator) TzError!Timezone {
@@ -309,7 +309,7 @@ fn findTransition(array: []const tzif.Transition, target: i64) i32 {
     return @as(i32, @intCast(left - 1));
 }
 
-/// time zone identifiers must only contain alpha-numeric characters
+/// Time zone identifiers must only contain alpha-numeric characters
 /// as well as '+', '-', '_' and '/' (path separator).
 pub fn identifierValid(idf: []const u8) bool {
     for (idf, 0..) |c, i| {

--- a/lib/calendar.zig
+++ b/lib/calendar.zig
@@ -1,7 +1,7 @@
 //! calendric stuff
+
 const std = @import("std");
 const assert = std.debug.assert;
-const Datetime = @import("./Datetime.zig");
 
 pub const isLeapYear = std.time.epoch.isLeapYear;
 
@@ -54,14 +54,6 @@ fn firstday(y: i16) i16 {
 /// Number of ISO weeks per year
 pub fn weeksPerYear(y: u16) u8 {
     return if (firstday(@as(i16, @intCast(y))) == 4 or firstday(@as(i16, @intCast(y - 1))) == 3) 53 else 52;
-}
-
-/// Number of ISO weeks per year, same as weeksPerYear but taking a datetime instance
-pub fn weeksPerYear_(dt: Datetime) u8 {
-    const this_y = Datetime.fromFields(.{ .year = dt.year }) catch unreachable;
-    if (this_y.weekday() == Datetime.Weekday.Thursday) return 53;
-    if (isLeapYear(dt.year) and this_y.weekday() == Datetime.Weekday.Wednesday) return 53;
-    return 52;
 }
 
 /// Mapping of Unix time [s] to number of leap seconds n_leap; n_leap = array-index + 11;

--- a/lib/errors.zig
+++ b/lib/errors.zig
@@ -1,6 +1,15 @@
 //! errors
 
-pub const ZdtError = RangeError || TzError || WinTzError;
+pub const ZdtError = FormatError || RangeError || TzError || WinTzError;
+
+pub const FormatError = error{
+    InvalidFormat,
+    InvalidDirective,
+    InvalidFraction,
+    ParseIntError,
+    WriterError,
+    OutOfMemory,
+};
 
 pub const RangeError = error{
     YearOutOfRange,

--- a/lib/tzif.zig
+++ b/lib/tzif.zig
@@ -1,5 +1,6 @@
 //! taken from Zig standard library, 0.12.0-dev.2059+42389cb9c,
 //! modified.
+
 const std = @import("std");
 const builtin = @import("builtin");
 

--- a/tests/test_calendar.zig
+++ b/tests/test_calendar.zig
@@ -1,4 +1,5 @@
 //! test calendric calculations from a users's perspective (no internal functionality)
+
 const std = @import("std");
 const testing = std.testing;
 const print = std.debug.print;
@@ -106,16 +107,6 @@ test "ymd_from_unix-days" {
     want = [_]u16{ 2023, 10, 23 };
     try testing.expectEqual(want, date);
     try testing.expectEqual(want, date_);
-}
-
-test "iso weeks in year" {
-    var i: u14 = 2000;
-    while (i < 2400) : (i += 1) {
-        const w = cal.weeksPerYear(i);
-        const w_ = cal.weeksPerYear_(try Datetime.fromFields(.{ .year = i }));
-        try testing.expectEqual(w, w_);
-        // if (w == 53) print("\ny: {d}", .{i});
-    }
 }
 
 // ---vv--- test generated with Python scripts ---vv---

--- a/tests/test_datetime.zig
+++ b/tests/test_datetime.zig
@@ -1,4 +1,5 @@
 //! test datetime from a users's perspective (no internal functionality)
+
 const std = @import("std");
 const testing = std.testing;
 
@@ -7,7 +8,7 @@ const Datetime = zdt.Datetime;
 const Duration = zdt.Duration;
 const Tz = zdt.Timezone;
 const ZdtError = zdt.ZdtError;
-const cal = zdt.calendar;
+const cal = @import("../lib/calendar.zig");
 
 const log = std.log.scoped(.test_datetime);
 

--- a/tests/test_duration.zig
+++ b/tests/test_duration.zig
@@ -1,4 +1,5 @@
 //! test duration from a users's perspective (no internal functionality)
+
 const std = @import("std");
 const testing = std.testing;
 

--- a/tests/test_string.zig
+++ b/tests/test_string.zig
@@ -1,4 +1,5 @@
 //! test stringIO from a user's perspective (no internal functionality)
+
 const std = @import("std");
 const builtin = @import("builtin");
 const testing = std.testing;
@@ -779,5 +780,5 @@ test "not ISO8601" {
     try testing.expectError(error.InvalidFormat, err);
 
     err = Datetime.fromISO8601("2014-02-03T23:00:00..314"); // invlid fractional secs separator
-    try testing.expectError(error.InvalidFormat, err);
+    try testing.expectError(error.ParseIntError, err);
 }

--- a/tests/test_string.zig
+++ b/tests/test_string.zig
@@ -687,10 +687,19 @@ test "parse ISO" {
     var dt_ref = try Datetime.fromFields(.{ .year = 2014, .month = 8 });
     var dt = try Datetime.fromISO8601("2014-08");
     try testing.expect(std.meta.eql(dt_ref, dt));
+    // TODO :
+    // dt = try Datetime.fromISO8601("201408");
+    // try testing.expect(std.meta.eql(dt_ref, dt));
 
     dt_ref = try Datetime.fromFields(.{ .year = 2014, .month = 8, .day = 23 });
     dt = try Datetime.fromISO8601("2014-08-23");
     try testing.expect(std.meta.eql(dt_ref, dt));
+    // TODO :
+    // dt = try Datetime.fromISO8601("20140823");
+    // try testing.expect(std.meta.eql(dt_ref, dt));
+
+    // TODO :
+    // year-doy
 
     dt_ref = try Datetime.fromFields(.{ .year = 2014, .month = 8, .day = 23, .hour = 12, .minute = 15 });
     dt = try Datetime.fromISO8601("2014-08-23 12:15");
@@ -755,7 +764,7 @@ test "not ISO8601" {
     err = Datetime.fromISO8601("2014"); // year-only not allowed
     try testing.expectError(error.InvalidFormat, err);
 
-    err = Datetime.fromISO8601("2014-12-32"); // invalid month
+    err = Datetime.fromISO8601("2014-12-32"); // invalid day
     try testing.expectError(error.DayOutOfRange, err);
 
     err = Datetime.fromISO8601("2014-12-31Z"); // date cannot have tz

--- a/tests/test_timezone.zig
+++ b/tests/test_timezone.zig
@@ -1,4 +1,5 @@
 //! test timezone from a users's perspective (no internal functionality)
+
 const builtin = @import("builtin");
 const std = @import("std");
 const testing = std.testing;
@@ -61,7 +62,7 @@ test "offset manifests in Unix time" {
 test "mem error" {
     const allocator = testing.failing_allocator;
     const err = Tz.fromTzfile("UTC", allocator);
-    try testing.expectError(error.OutOfMemory, err);
+    try testing.expectError(ZdtError.TZifUnreadable, err);
 }
 
 test "tzfile tz manifests in Unix time" {


### PR DESCRIPTION
maybe #14

TODO : benchmark.

In theory, if passed-by-value, the Zig compiler should be able to figure out what to pass-by-reference instead under the hood. Does this work?