### PR TITLE
Add parsing option for English names, independent of locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Types of changes
 
 ## Unreleased
 
+### Added
+
+- option to use a modifier in parsing directives
+- allow parsing of English month/day names, independent of the current locale
+
 ## 2024-10-12, v0.3.5
 
 ### Added

--- a/examples/ex_locale.zig
+++ b/examples/ex_locale.zig
@@ -44,7 +44,17 @@ pub fn main() !void {
 
     // string to datetime
     //
-    // TODO :
+    const input = "Mittwoch, 23. Januar 1974, 03:17h";
+    const parsed = try Datetime.fromString(input, "%A, %d. %B %Y, %H:%Mh");
+    println("", .{});
+    println("parsed '{s}'\n  to '{s}'", .{ input, parsed });
+
+    // by adding a modifier character, you can always parse English month names,
+    // independent of the locale:
+    const input_eng = "Wednesday, January 23 1974, 03:17h";
+    const parsed_eng = try Datetime.fromString(input_eng, "%:A, %:B %d %Y, %H:%Mh");
+    println("", .{});
+    println("parsed '{s}'\n  to '{s}'", .{ input_eng, parsed_eng });
 }
 
 fn println(comptime fmt: []const u8, args: anytype) void {

--- a/examples/ex_locale.zig
+++ b/examples/ex_locale.zig
@@ -30,6 +30,8 @@ pub fn main() !void {
     var buf = std.ArrayList(u8).init(allocator);
     defer buf.deinit();
 
+    // datetime to string
+    //
     try dt.toString("%a, %b %d %Y, %H:%Mh", buf.writer());
     println("", .{});
     println("formatted {s}\n  to '{s}'", .{ dt, buf.items });
@@ -39,6 +41,10 @@ pub fn main() !void {
     try dt.toString("%A, %B %d %Y, %H:%Mh", buf.writer());
     println("", .{});
     println("formatted {s}\n  to '{s}'", .{ dt, buf.items });
+
+    // string to datetime
+    //
+    // TODO :
 }
 
 fn println(comptime fmt: []const u8, args: anytype) void {

--- a/examples/ex_strings.zig
+++ b/examples/ex_strings.zig
@@ -39,7 +39,7 @@ pub fn main() !void {
     println("", .{});
     println("---> (usage): parse some non-standard format", .{});
     const dayfirst_dtstr = "23.7.2021, 9:45h";
-    parsed = try Datetime.fromString("%d.%m.%Y, %H:%Mh", dayfirst_dtstr);
+    parsed = try Datetime.fromString(dayfirst_dtstr, "%d.%m.%Y, %H:%Mh");
     // zdt.Datetime.strptime is also available for people used to strftime/strptime
     assert(parsed.day == 23);
     println("parsed '{s}'\n  to {s}", .{ dayfirst_dtstr, parsed });

--- a/lib/Datetime.zig
+++ b/lib/Datetime.zig
@@ -82,6 +82,20 @@ pub const Weekday = enum(u8) {
     pub fn longName(w: Weekday) []const u8 {
         return @tagName(w);
     }
+
+    pub fn nameToInt(name: []const u8) !u8 {
+        inline for (std.meta.fields(Weekday)) |f| {
+            if (std.mem.eql(u8, name, f.name)) return f.value;
+        }
+        return error.DayOutOfRange;
+    }
+
+    pub fn nameShortToInt(name: []const u8) !u8 {
+        inline for (std.meta.fields(Weekday)) |f| {
+            if (std.mem.eql(u8, name, f.name[0..3])) return f.value;
+        }
+        return error.DayOutOfRange;
+    }
 };
 
 /// Enum-representation of a month, with January being 1.
@@ -106,6 +120,20 @@ pub const Month = enum(u8) {
 
     pub fn longName(m: Month) []const u8 {
         return @tagName(m);
+    }
+
+    pub fn nameToInt(name: []const u8) !u8 {
+        inline for (std.meta.fields(Month)) |f| {
+            if (std.mem.eql(u8, name, f.name)) return f.value;
+        }
+        return error.MonthOutOfRange;
+    }
+
+    pub fn nameShortToInt(name: []const u8) !u8 {
+        inline for (std.meta.fields(Month)) |f| {
+            if (std.mem.eql(u8, name, f.name[0..3])) return f.value;
+        }
+        return error.MonthOutOfRange;
     }
 };
 

--- a/lib/string.zig
+++ b/lib/string.zig
@@ -704,6 +704,18 @@ fn allDayNames() ![7][sz_normal]u8 {
     return result;
 }
 
+fn allDayNamesEng() ![7][sz_normal]u8 {
+    return [7][sz_normal]u8{
+        [6]u8{ 'S', 'u', 'n', 'd', 'a', 'y' } ++ std.mem.zeroes([sz_normal - 6]u8),
+        [6]u8{ 'M', 'o', 'n', 'd', 'a', 'y' } ++ std.mem.zeroes([sz_normal - 6]u8),
+        [7]u8{ 'T', 'u', 'e', 's', 'd', 'a', 'y' } ++ std.mem.zeroes([sz_normal - 7]u8),
+        [9]u8{ 'W', 'e', 'd', 'n', 'e', 's', 'd', 'a', 'y' } ++ std.mem.zeroes([sz_normal - 9]u8),
+        [8]u8{ 'T', 'h', 'u', 'r', 's', 'd', 'a', 'y' } ++ std.mem.zeroes([sz_normal - 8]u8),
+        [6]u8{ 'F', 'r', 'i', 'd', 'a', 'y' } ++ std.mem.zeroes([sz_normal - 6]u8),
+        [8]u8{ 'S', 'a', 't', 'u', 'r', 'd', 'a', 'y' } ++ std.mem.zeroes([sz_normal - 8]u8),
+    };
+}
+
 fn allDayNamesShort() ![7][sz_abbr]u8 {
     var result: [7][sz_abbr]u8 = undefined;
     for (result, 0..) |_, i| result[i] = try getDayNameAbbr(@truncate(i));
@@ -745,6 +757,8 @@ test "all names" {
     }
 }
 
+// TODO : make allnames a function parameter so that this can also be used
+// to parse English-only names
 fn parseDayName(string: []const u8, idx_ptr: *usize) !u8 {
     const allnames = try allDayNames();
     var daynum: u8 = 0;

--- a/tests/test_datetime.zig
+++ b/tests/test_datetime.zig
@@ -339,12 +339,24 @@ test "weekday enum" {
     try testing.expectEqual(Datetime.Weekday.Thursday, dt.weekday());
     try testing.expectEqualStrings("Thu", dt.weekday().shortName());
     try testing.expectEqualStrings("Thursday", dt.weekday().longName());
+
+    var d = try Datetime.Weekday.nameToInt("Saturday");
+    try testing.expectEqual(6, d);
+
+    d = try Datetime.Weekday.nameShortToInt("Thu");
+    try testing.expectEqual(4, d);
 }
 
 test "month enum" {
     const dt = try Datetime.fromFields(.{ .year = 1970 });
     try testing.expectEqualStrings("Jan", dt.monthEnum().shortName());
     try testing.expectEqualStrings("January", dt.monthEnum().longName());
+
+    var m = try Datetime.Month.nameToInt("June");
+    try testing.expectEqual(6, m);
+
+    m = try Datetime.Month.nameShortToInt("Apr");
+    try testing.expectEqual(4, m);
 }
 
 test "next weekday" {

--- a/tests/test_string.zig
+++ b/tests/test_string.zig
@@ -682,7 +682,12 @@ test "parse with month name and day, user-defined locale" {
             .dt = try Datetime.fromFields(.{ .year = 2021, .month = 12, .day = 31, .hour = 17 }),
             .directive = "%A %d %B %Y, %I %p",
         },
-        // TODO : add test cases with English names
+        // locale is not English, however we must still be able to parse English names:
+        .{
+            .string = "Friday Fri 31 December Dec 2021, 5 pm",
+            .dt = try Datetime.fromFields(.{ .year = 2021, .month = 12, .day = 31, .hour = 17 }),
+            .directive = "%:A %:a %d %:B %:b %Y, %I %p",
+        },
     };
 
     for (cases) |case| {

--- a/tests/test_string.zig
+++ b/tests/test_string.zig
@@ -682,6 +682,7 @@ test "parse with month name and day, user-defined locale" {
             .dt = try Datetime.fromFields(.{ .year = 2021, .month = 12, .day = 31, .hour = 17 }),
             .directive = "%A %d %B %Y, %I %p",
         },
+        // TODO : add test cases with English names
     };
 
     for (cases) |case| {


### PR DESCRIPTION
- directives: `%:a %:A %:b %:B`
- related: #29