### PR TITLE
Remove constCast in Timezone.deinit

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ defer _ = gpa.deinit();
 const allocator = gpa.allocator();
 
 // zdt embeds the IANA tz database:
-const tz_LA = try zdt.Timezone.fromTzdata("America/Los_Angeles", allocator);
+var tz_LA = try zdt.Timezone.fromTzdata("America/Los_Angeles", allocator);
 defer tz_LA.deinit();
 
 // you can also use your system's tz data at runtime;
 // this will very likely not work on Windows, so we use the embedded version here as well.
-const tz_Paris = switch (builtin.os.tag) {
+var tz_Paris = switch (builtin.os.tag) {
     .windows => try zdt.Timezone.fromTzdata("Europe/Paris", allocator),
     else => try zdt.Timezone.runtimeFromTzfile("Europe/Paris", zdt.Timezone.tzdb_prefix, allocator),
 };

--- a/examples/ex_demo.zig
+++ b/examples/ex_demo.zig
@@ -10,12 +10,12 @@ pub fn main() !void {
     const allocator = gpa.allocator();
 
     // zdt embeds the IANA tz database:
-    const tz_LA = try zdt.Timezone.fromTzdata("America/Los_Angeles", allocator);
+    var tz_LA = try zdt.Timezone.fromTzdata("America/Los_Angeles", allocator);
     defer tz_LA.deinit();
 
     // you can also use your system's tz data at runtime;
     // this will very likely not work on Windows, so we use the embedded version here as well.
-    const tz_Paris = switch (builtin.os.tag) {
+    var tz_Paris = switch (builtin.os.tag) {
         .windows => try zdt.Timezone.fromTzdata("Europe/Paris", allocator),
         else => try zdt.Timezone.runtimeFromTzfile("Europe/Paris", zdt.Timezone.tzdb_prefix, allocator),
     };

--- a/examples/ex_timezones.zig
+++ b/examples/ex_timezones.zig
@@ -24,7 +24,7 @@ pub fn main() !void {
     println("time zone database version: {s}", .{Tz.tzdb_version});
     println("path to local tz database: {s}\n", .{Tz.tzdb_prefix});
 
-    const tz_berlin: Tz = try Tz.fromTzdata("Europe/Berlin", allocator);
+    var tz_berlin: Tz = try Tz.fromTzdata("Europe/Berlin", allocator);
     defer tz_berlin.deinit();
     var now_berlin: Datetime = try Datetime.now(.{ .tz = &tz_berlin });
     const now_utc: Datetime = Datetime.nowUTC();
@@ -32,7 +32,7 @@ pub fn main() !void {
     println("Now, Berlin time : {s} ({s})", .{ now_berlin, now_berlin.tzAbbreviation() });
     println("Datetimes have UTC offset / time zone? : {}, {}\n", .{ now_utc.isAware(), now_berlin.isAware() });
 
-    const my_tz: Tz = try Tz.tzLocal(allocator);
+    var my_tz: Tz = try Tz.tzLocal(allocator);
     defer my_tz.deinit();
     var now_local = try now_berlin.tzConvert(.{ .tz = &my_tz });
     println("My time zone : {s}", .{my_tz.name()});
@@ -40,7 +40,7 @@ pub fn main() !void {
     println("Now, my time zone : {s} ({s})", .{ now_local, now_local.tzAbbreviation() });
     println("", .{});
 
-    const tz_ny = try Tz.fromTzdata("America/New_York", allocator);
+    var tz_ny = try Tz.fromTzdata("America/New_York", allocator);
     defer tz_ny.deinit();
     var now_ny: Datetime = try now_local.tzConvert(.{ .tz = &tz_ny });
     println("Now in New York : {s} ({s})", .{ now_ny, now_ny.tzAbbreviation() });

--- a/lib/Timezone.zig
+++ b/lib/Timezone.zig
@@ -133,14 +133,12 @@ pub fn runtimeFromTzfile(identifier: []const u8, db_path: []const u8, allocator:
 }
 
 /// Clear a TZ instance and free potentially used memory
-pub fn deinit(tz: *const Timezone) void {
-    // must remove const qualifier to clear present time zone rules
-    const _tz_ptr = @constCast(tz);
-    _tz_ptr.__name_data = std.mem.zeroes([cap_name_data]u8);
-    _tz_ptr.__name_data_len = 0;
+pub fn deinit(tz: *Timezone) void {
+    tz.__name_data = std.mem.zeroes([cap_name_data]u8);
+    tz.__name_data_len = 0;
 
     switch (tz.rules) {
-        .tzif => _tz_ptr.rules.tzif.deinit(),
+        .tzif => |*_tzif| _tzif.deinit(),
         .posixtz => return,
         .utc => return,
     }

--- a/tests/test_timezone.zig
+++ b/tests/test_timezone.zig
@@ -89,7 +89,7 @@ test "tz deinit is mem-safe" {
 }
 
 test "tzfile tz manifests in Unix time" {
-    const tzinfo = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
+    var tzinfo = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
     defer tzinfo.deinit();
 
     var dt = try Datetime.fromFields(.{ .year = 1970, .nanosecond = 1, .tz_options = .{ .tz = &tzinfo } });
@@ -107,7 +107,7 @@ test "local tz db, from specified or default prefix" {
 
     const db = Tz.tzdb_prefix;
     // log.warn("system tzdb prefix: {s}", .{db});
-    const tzinfo = try Tz.runtimeFromTzfile("Europe/Berlin", db, testing.allocator);
+    var tzinfo = try Tz.runtimeFromTzfile("Europe/Berlin", db, testing.allocator);
     defer tzinfo.deinit();
 
     var dt = try Datetime.fromFields(.{ .year = 1970, .nanosecond = 1, .tz_options = .{ .tz = &tzinfo } });
@@ -120,7 +120,7 @@ test "local tz db, from specified or default prefix" {
 }
 
 test "embedded tzdata" {
-    const tzinfo = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
+    var tzinfo = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
     defer tzinfo.deinit();
 
     var dt = try Datetime.fromFields(.{ .year = 1970, .nanosecond = 1, .tz_options = .{ .tz = &tzinfo } });
@@ -151,7 +151,7 @@ test "local tz" {
     try testing.expect(now.tz == null);
     try testing.expect(now.utc_offset == null);
 
-    const tzinfo = try Tz.tzLocal(testing.allocator);
+    var tzinfo = try Tz.tzLocal(testing.allocator);
     defer tzinfo.deinit();
     now = try Datetime.now(.{ .tz = &tzinfo });
 
@@ -161,8 +161,8 @@ test "local tz" {
 }
 
 test "DST transitions" {
-    const tzinfo = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
-    defer _ = tzinfo.deinit();
+    var tzinfo = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
+    defer tzinfo.deinit();
 
     // DST off --> DST on (missing datetime), 2023-03-26
     var dt_std = try Datetime.fromUnix(1679792399, Duration.Resolution.second, .{ .tz = &tzinfo });
@@ -196,8 +196,8 @@ test "DST transitions" {
 }
 
 test "wall diff vs. abs diff" {
-    const tzinfo = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
-    defer _ = tzinfo.deinit();
+    var tzinfo = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
+    defer tzinfo.deinit();
 
     // DST off --> DST on (missing datetime), 2023-03-26
     const dt_std = try Datetime.fromUnix(
@@ -226,8 +226,8 @@ test "wall diff vs. abs diff" {
 }
 
 test "tz has name and abbreviation" {
-    const tzinfo = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
-    defer _ = tzinfo.deinit();
+    var tzinfo = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
+    defer tzinfo.deinit();
 
     var dt = try Datetime.fromFields(.{ .year = 2023, .month = 2, .tz_options = .{ .tz = &tzinfo } });
     try testing.expectEqualStrings("Europe/Berlin", dt.tzName());
@@ -247,15 +247,15 @@ test "tz has name and abbreviation" {
 }
 
 test "longest tz name" {
-    const tzinfo = try Tz.fromTzdata("America/Argentina/ComodRivadavia", testing.allocator);
-    defer _ = tzinfo.deinit();
+    var tzinfo = try Tz.fromTzdata("America/Argentina/ComodRivadavia", testing.allocator);
+    defer tzinfo.deinit();
     var dt = try Datetime.fromFields(.{ .year = 2023, .month = 2, .tz_options = .{ .tz = &tzinfo } });
     try testing.expectEqualStrings("America/Argentina/ComodRivadavia", dt.tzName());
 }
 
 test "early LMT, late CET" {
-    const tzinfo = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
-    defer _ = tzinfo.deinit();
+    var tzinfo = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
+    defer tzinfo.deinit();
 
     var dt = try Datetime.fromFields(.{ .year = 1880, .tz_options = .{ .tz = &tzinfo } });
     try testing.expectEqualStrings("LMT", dt.tzAbbreviation());
@@ -266,8 +266,8 @@ test "early LMT, late CET" {
 }
 
 test "tz name and abbr correct after localize" {
-    const tz_ny = try Tz.fromTzdata("America/New_York", testing.allocator);
-    defer _ = tz_ny.deinit();
+    var tz_ny = try Tz.fromTzdata("America/New_York", testing.allocator);
+    defer tz_ny.deinit();
 
     var now_local: Datetime = try Datetime.now(.{ .tz = &tz_ny });
     try testing.expectEqualStrings("America/New_York", now_local.tzName());
@@ -301,10 +301,10 @@ test "tz name and abbr correct after localize" {
 }
 
 test "tz name and abbr correct after conversion" {
-    const tz_berlin = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
-    defer _ = tz_berlin.deinit();
-    const tz_denver = try Tz.fromTzdata("America/Denver", testing.allocator);
-    defer _ = tz_denver.deinit();
+    var tz_berlin = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
+    defer tz_berlin.deinit();
+    var tz_denver = try Tz.fromTzdata("America/Denver", testing.allocator);
+    defer tz_denver.deinit();
 
     var dt = try Datetime.fromFields(.{ .year = 2023, .tz_options = .{ .tz = &tz_berlin } });
     var converted: Datetime = try dt.tzConvert(.{ .tz = &tz_denver });
@@ -322,34 +322,34 @@ test "tz name and abbr correct after conversion" {
 }
 
 test "non-existent datetime" {
-    const tzinfo = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
+    var tzinfo = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
     defer tzinfo.deinit();
 
     var dt = Datetime.fromFields(.{ .year = 2023, .month = 3, .day = 26, .hour = 2, .tz_options = .{ .tz = &tzinfo } });
     try testing.expectError(ZdtError.NonexistentDatetime, dt);
 
-    const tzinfo_ = try Tz.fromTzdata("America/Denver", testing.allocator);
+    var tzinfo_ = try Tz.fromTzdata("America/Denver", testing.allocator);
     defer tzinfo_.deinit();
     dt = Datetime.fromFields(.{ .year = 2023, .month = 3, .day = 12, .hour = 2, .minute = 59, .second = 59, .tz_options = .{ .tz = &tzinfo_ } });
     try testing.expectError(ZdtError.NonexistentDatetime, dt);
 }
 
 test "ambiguous datetime" {
-    const tzinfo = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
+    var tzinfo = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
     defer tzinfo.deinit();
 
     var dt = Datetime.fromFields(.{ .year = 2023, .month = 10, .day = 29, .hour = 2, .tz_options = .{ .tz = &tzinfo } });
     try testing.expectError(ZdtError.AmbiguousDatetime, dt);
 
-    const tzinfo_ = try Tz.fromTzdata("America/Denver", testing.allocator);
+    var tzinfo_ = try Tz.fromTzdata("America/Denver", testing.allocator);
     defer tzinfo_.deinit();
     dt = Datetime.fromFields(.{ .year = 2023, .month = 11, .day = 5, .hour = 1, .minute = 59, .second = 59, .tz_options = .{ .tz = &tzinfo_ } });
     try testing.expectError(ZdtError.AmbiguousDatetime, dt);
 }
 
 test "ambiguous datetime / DST fold" {
-    const tz_berlin = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
-    defer _ = tz_berlin.deinit();
+    var tz_berlin = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
+    defer tz_berlin.deinit();
 
     // DST on, offset 7200 s
     var dt_early = try Datetime.fromFields(.{ .year = 2023, .month = 10, .day = 29, .hour = 2, .dst_fold = 0, .tz_options = .{ .tz = &tz_berlin } });
@@ -358,7 +358,7 @@ test "ambiguous datetime / DST fold" {
     try testing.expectEqual(7200, dt_early.utc_offset.?.seconds_east);
     try testing.expectEqual(3600, dt_late.utc_offset.?.seconds_east);
 
-    const tz_mountain = try Tz.fromTzdata("America/Denver", testing.allocator);
+    var tz_mountain = try Tz.fromTzdata("America/Denver", testing.allocator);
     defer tz_mountain.deinit();
     dt_early = try Datetime.fromFields(.{ .year = 2023, .month = 11, .day = 5, .hour = 1, .minute = 59, .second = 59, .dst_fold = 0, .tz_options = .{ .tz = &tz_mountain } });
     dt_late = try Datetime.fromFields(.{ .year = 2023, .month = 11, .day = 5, .hour = 1, .minute = 59, .second = 59, .dst_fold = 1, .tz_options = .{ .tz = &tz_mountain } });
@@ -367,8 +367,8 @@ test "ambiguous datetime / DST fold" {
 }
 
 test "tz without transitions at UTC+9" {
-    const tzinfo = try Tz.fromTzdata("Asia/Tokyo", testing.allocator);
-    defer _ = tzinfo.deinit();
+    var tzinfo = try Tz.fromTzdata("Asia/Tokyo", testing.allocator);
+    defer tzinfo.deinit();
 
     var dt = try Datetime.fromFields(.{ .year = 2023, .month = 3, .day = 26, .hour = 2, .tz_options = .{ .tz = &tzinfo } });
     try testing.expectEqual(@as(i32, 9 * 3600), dt.utc_offset.?.seconds_east);
@@ -381,8 +381,8 @@ test "tz without transitions at UTC+9" {
 }
 
 test "make datetime aware" {
-    const tzinfo = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
-    defer _ = tzinfo.deinit();
+    var tzinfo = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
+    defer tzinfo.deinit();
 
     const dt_naive = try Datetime.fromUnix(0, Duration.Resolution.second, null);
     try testing.expect(dt_naive.utc_offset == null);
@@ -401,8 +401,8 @@ test "make datetime aware" {
 }
 
 test "replace tz in aware datetime" {
-    const tz_Berlin = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
-    defer _ = tz_Berlin.deinit();
+    var tz_Berlin = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
+    defer tz_Berlin.deinit();
 
     const dt_utc = Datetime.epoch;
     const dt_berlin = try dt_utc.tzLocalize(.{ .tz = &tz_Berlin });
@@ -416,8 +416,8 @@ test "replace tz in aware datetime" {
 }
 
 test "replace tz fails for non-existent datetime in target tz" {
-    const tz_Berlin = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
-    defer _ = tz_Berlin.deinit();
+    var tz_Berlin = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
+    defer tz_Berlin.deinit();
 
     const dt_utc = try Datetime.fromFields(.{ .year = 2023, .month = 3, .day = 26, .hour = 2, .tz_options = .{ .utc_offset = UTCoffset.UTC } });
     const err = dt_utc.tzLocalize(.{ .tz = &tz_Berlin });
@@ -426,7 +426,7 @@ test "replace tz fails for non-existent datetime in target tz" {
 }
 
 test "convert time zone" {
-    const tzinfo = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
+    var tzinfo = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
     defer tzinfo.deinit();
 
     const dt_naive = try Datetime.fromUnix(42, Duration.Resolution.nanosecond, null);
@@ -435,7 +435,7 @@ test "convert time zone" {
 
     const dt_Berlin = try Datetime.fromUnix(42, Duration.Resolution.nanosecond, .{ .tz = &tzinfo });
 
-    const tzinfo_ = try Tz.fromTzdata("America/New_York", testing.allocator);
+    var tzinfo_ = try Tz.fromTzdata("America/New_York", testing.allocator);
     defer tzinfo_.deinit();
     const dt_NY = try dt_Berlin.tzConvert(.{ .tz = &tzinfo_ });
 
@@ -445,8 +445,8 @@ test "convert time zone" {
 }
 
 test "floor to date changes UTC offset" {
-    const tzinfo = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
-    defer _ = tzinfo.deinit();
+    var tzinfo = try Tz.fromTzdata("Europe/Berlin", testing.allocator);
+    defer tzinfo.deinit();
 
     var dt = try Datetime.fromFields(.{ .year = 2023, .month = 10, .day = 29, .hour = 5, .tz_options = .{ .tz = &tzinfo } });
     var dt_floored = try dt.floorTo(Duration.Timespan.day);
@@ -1067,14 +1067,14 @@ test "load a lot of zones" {
     };
 
     inline for (zones) |zone| {
-        const tz_a = try Tz.fromTzdata(zone, testing.allocator);
+        var tz_a = try Tz.fromTzdata(zone, testing.allocator);
         const dt_a = try Datetime.fromUnix(1, Duration.Resolution.second, .{ .tz = &tz_a });
         try testing.expect(dt_a.utc_offset != null);
         try testing.expectEqualStrings(zone, dt_a.tzName());
         tz_a.deinit();
 
         if (builtin.os.tag != .windows) {
-            const tz_b = try Tz.runtimeFromTzfile(zone, Tz.tzdb_prefix, testing.allocator);
+            var tz_b = try Tz.runtimeFromTzfile(zone, Tz.tzdb_prefix, testing.allocator);
             const dt_b = try Datetime.fromUnix(1, Duration.Resolution.second, .{ .tz = &tz_b });
             try testing.expect(dt_b.utc_offset != null);
             try testing.expectEqualStrings(zone, dt_b.tzName());


### PR DESCRIPTION
Closes https://github.com/FObersteiner/zdt/issues/32

> create a Timezone, set it to a Datetime, de-initialize it, and overwrite it with a new one

I think that it is fine to say that this is undefined behavior since Datetime takes a pointer to a Timezone so it implicitely means that Timezone should live as long as Datetime for it to be correct.

Also, having const Timezone doesn't prevent this footgun: create a Timezone, set it to a Datetime, and de-initialize. This result in a wrong offset too.

---

This change also prevents from doing
```zig
zdt.Timezone.UTC.deinit();
```
which I don't know why someone would do that but it will result in a segfault with current behavior.