### PR TITLE
Datetime.fromat revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Types of changes
 
 ## [Unreleased]
 
+### Added
+
+- ability for `Datetime.format` to ingest formatting directives like `Datetime.toString` can use
+
 ## 2025-03-23, v0.6.2
 
 ### Changed

--- a/examples/ex_datetime.zig
+++ b/examples/ex_datetime.zig
@@ -24,7 +24,8 @@ pub fn main() !void {
     const now_s = try now.floorTo(Duration.Timespan.second);
     println("(nanos removed) : {s}", .{now_s});
     const now_date = try now.floorTo(Duration.Timespan.day);
-    println("         (date) : {s}", .{now_date});
+    println("           (date) : {s}", .{now_date});
+    println("(date, formatted) : {%Y-%m-%d}", .{now_date});
 }
 
 fn println(comptime fmt: []const u8, args: anytype) void {

--- a/lib/Datetime.zig
+++ b/lib/Datetime.zig
@@ -906,19 +906,30 @@ pub fn EasterDateJulian(year: u16) !Datetime {
     });
 }
 
-/// Formatted printing for Datetime. Defaults to ISO8601 / RFC3339nano.
-/// Nanoseconds are displayed if not zero. To get milli- or microsecond
-/// precision, use formatting directive 's:.3' (ms) or 's:.6' (us).
+/// Custom printing for the Datetime struct, to be used e.g. in std.debug.print.
+/// Defaults to ISO8601 / RFC3339nano format.
+///
+/// Nanoseconds are displayed if not zero. To get milli- or microsecond precision,
+/// use formatting directive '{s:.3}' (ms) or '{s:.6}' (us).
+///
+/// If a formatting directive other than 's' or empty is provided, the method
+/// tries to interpret it as regular datetime formatting directive(s), as the ones
+/// used in Datetime.toString.
+///
+/// EX:
+/// std.debug.print("{%Y-%m}", .{dt});
+/// // ...would for instance evaluate to
+/// >>> "2025-03"
+///
 pub fn format(
     dt: Datetime,
     comptime fmt: []const u8,
     options: std.fmt.FormatOptions,
     writer: anytype,
-) !void {
-    // TODO : if fmt is not ('s' or empty), we could try to interpret fmt as a directive
-    // and return try str.tokenizeAndPrint(&dt, fmt, writer)
-    // However, this requires to resolve the possible error set.
-    _ = fmt;
+) anyerror!void { // have to use 'anyerror' here due to the 'anytype' writer
+    if (!(std.mem.eql(u8, fmt, "s") or fmt.len == 0))
+        return try str.tokenizeAndPrint(&dt, fmt, writer);
+
     try writer.print(
         "{d:0>4}-{d:0>2}-{d:0>2}T{d:0>2}:{d:0>2}:{d:0>2}",
         .{ dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second },

--- a/tests/test_string.zig
+++ b/tests/test_string.zig
@@ -19,6 +19,8 @@ const td = zdt.Duration;
 const Tz = zdt.Timezone;
 const UTCoffset = zdt.UTCoffset;
 
+const Error = error{ UnsupportedOS, OutOfMemory, InvalidFormat, InvalidDirective };
+
 const TestCase = struct {
     string: []const u8,
     dt: Datetime,
@@ -705,7 +707,7 @@ test "parse %I and am/pm errors" {
     try testing.expectError(error.InvalidFormat, err);
 
     err = Datetime.fromString("9 a", "%I %p"); // incomplete 'am'
-    try testing.expectError(error.InvalidFormat, err);
+    try testing.expectError(Error.InvalidFormat, err);
 
     err = Datetime.fromString("0 am", "%I %p"); // invalid hour
     try testing.expectError(error.InvalidFormat, err);
@@ -823,7 +825,7 @@ test "parsing directives do not match fields in string" {
     try testing.expectError(error.InvalidFormat, err);
 
     err = Datetime.fromString("1970-01-01 00:00:00 +7", "%Y-%m-%d %H:%M:%S %z");
-    try testing.expectError(error.InvalidFormat, err);
+    try testing.expectError(Error.InvalidFormat, err);
 }
 
 test "parse with literal characters" {
@@ -1126,8 +1128,8 @@ test "not ISO8601" {
     try testing.expectError(error.InvalidFormat, err);
 
     err = Datetime.fromISO8601("2014-02-03T23:00:00..314"); // invlid fractional secs separator
-    try testing.expectError(error.InvalidFormat, err);
+    try testing.expectError(Error.InvalidFormat, err);
 
     err = Datetime.fromISO8601("2014-08-23T12:15:56+-0200"); // invalid offset
-    try testing.expectError(error.InvalidFormat, err);
+    try testing.expectError(Error.InvalidFormat, err);
 }

--- a/zdt.zig
+++ b/zdt.zig
@@ -15,7 +15,7 @@ pub const ZdtError = @import("./lib/errors.zig").ZdtError;
 // make sure 'internal' tests are also executed:
 const calendar = @import("./lib/calendar.zig");
 const posix = @import("./lib/posixtz.zig");
-const string = @import("./lib/string.zig");
+const str = @import("./lib/string.zig");
 const tzif = @import("./lib/tzif.zig");
 
 test {
@@ -25,6 +25,6 @@ test {
     _ = Duration;
     _ = calendar;
     _ = posix;
-    _ = string;
+    _ = str;
     _ = tzif;
 }


### PR DESCRIPTION
let `Datetime.format` be able to handle "regular" formatting directives as the ones applicable for `Datetime.toString`.